### PR TITLE
Scrape terminal window style and apply to theme detail preview

### DIFF
--- a/src/app/themes/[slug]/page.tsx
+++ b/src/app/themes/[slug]/page.tsx
@@ -59,6 +59,34 @@ export default async function ThemeDetailPage({ params }: Props) {
   const colors = parseColors(theme.colors_json);
   const apps: string[] = theme.apps_json ? JSON.parse(theme.apps_json) : [];
 
+  interface TerminalStyle {
+    source?: string;
+    background_opacity?: number;
+    padding?: number;
+    font_family?: string;
+    cursor_style?: "block" | "beam" | "underline";
+    rounding?: number;
+  }
+  const termStyle: TerminalStyle | null = theme.terminal_style_json
+    ? JSON.parse(theme.terminal_style_json)
+    : null;
+
+  function hexToRgba(hex: string, alpha: number): string {
+    const h = hex.replace(/^#/, "");
+    const r = parseInt(h.slice(0, 2), 16);
+    const g = parseInt(h.slice(2, 4), 16);
+    const b = parseInt(h.slice(4, 6), 16);
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  }
+
+  const bgHex = colors?.background ?? "#1a1a2e";
+  const opacity = termStyle?.background_opacity ?? 1;
+  const cardBg = opacity < 1 ? hexToRgba(bgHex, opacity) : bgHex;
+  const cardRadius = termStyle?.rounding;
+  const innerPadding = termStyle?.padding;
+  const termFont = termStyle?.font_family;
+  const cursorStyle = termStyle?.cursor_style ?? "block";
+
   // Derive branch and path prefix for resolving relative README URLs
   const readmeBranch = theme.default_branch ?? "main";
   let readmePathPrefix = "";
@@ -107,7 +135,17 @@ export default async function ThemeDetailPage({ params }: Props) {
               <h2 className="font-mono text-xs text-muted-foreground uppercase tracking-wider">
                 preview
               </h2>
-              <Card className="overflow-hidden p-0" style={{ backgroundColor: colors.background ?? "#1a1a2e" }}>
+              <Card
+                className="overflow-hidden p-0"
+                style={{
+                  backgroundColor: cardBg,
+                  borderRadius: cardRadius !== undefined ? `${cardRadius}px` : undefined,
+                  fontFamily: termFont
+                    ? `"${termFont}", "JetBrains Mono", "Fira Code", "Hack", monospace`
+                    : undefined,
+                  backdropFilter: opacity < 1 ? "blur(8px)" : undefined,
+                }}
+              >
                 <div className="flex items-center gap-2 px-4 py-2 border-b border-white/5">
                   <span className="size-2.5 rounded-full bg-red-500/70" />
                   <span className="size-2.5 rounded-full bg-yellow-500/70" />
@@ -117,10 +155,13 @@ export default async function ThemeDetailPage({ params }: Props) {
                   </span>
                 </div>
                 <div
-                  className="p-5 font-mono text-[12px] leading-tight overflow-x-auto"
-                  style={{ color: colors.foreground ?? "#ccc" }}
+                  className="font-mono text-[11px] leading-tight overflow-hidden"
+                  style={{
+                    color: colors.foreground ?? "#ccc",
+                    padding: innerPadding !== undefined ? `${innerPadding}px` : "20px",
+                  }}
                 >
-                  <div className="flex gap-6 items-start min-w-max">
+                  <div className="flex gap-4 items-start">
                     <pre
                       className="text-[8px] leading-[1.05] whitespace-pre select-none shrink-0"
                       style={{ color: colors.accent ?? colors.color4 ?? "#4a9eff" }}
@@ -155,39 +196,93 @@ export default async function ThemeDetailPage({ params }: Props) {
                     </pre>
 
                     <div className="space-y-3 whitespace-pre">
-                      <div>
-                        <div style={{ color: colors.color8 ?? "#666" }}>{`┌──────── Hardware ────────`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color1 ?? "#ff5555" }}>CPU</span>{`: x86_64 (8 cores)`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color2 ?? "#50fa7b" }}>GPU</span>{`: Integrated Graphics`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color3 ?? "#f1fa8c" }}>Disk</span>{`: 120 / 500 GiB (24%)`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color4 ?? "#6272a4" }}>Memory</span>{`: 8 / 16 GiB (50%)`}</div>
-                        <div style={{ color: colors.color8 ?? "#666" }}>{`└──────────────────────────`}</div>
-                      </div>
+                      {(() => {
+                        const dim = colors.color8 ?? "#666";
+                        const key = colors.color2 ?? colors.accent ?? "#50fa7b";
+                        const dash = (n: number) => "─".repeat(n);
+                        const WIDTH = 40;
+                        const top = (title: string) => {
+                          const inner = WIDTH - 2 - 2 - title.length;
+                          const l = Math.floor(inner / 2);
+                          const r = inner - l;
+                          return `┌${dash(l)} ${title} ${dash(r)}┐`;
+                        };
+                        const bot = `└${dash(WIDTH - 2)}┘`;
+                        const Row = ({ branch, label, value, last }: { branch: "first" | "mid" | "last"; label: string; value: React.ReactNode; last?: boolean }) => {
+                          const prefix = branch === "first" ? "  " : branch === "last" ? "│ └" : "│ ├";
+                          return (
+                            <div>
+                              <span style={{ color: dim }}>{prefix}</span>
+                              <span style={{ color: key }}>{` ${label}`}</span>
+                              <span>{`: `}</span>
+                              {value}
+                            </div>
+                          );
+                        };
+                        return (
+                          <>
+                            <div>
+                              <div style={{ color: dim }}>{top("Hardware")}</div>
+                              <Row branch="first" label="PC" value={"omarchy-host"} />
+                              <Row branch="mid" label="CPU" value={"x86_64 (8 cores)"} />
+                              <Row branch="mid" label="GPU" value={"Integrated Graphics"} />
+                              <Row branch="mid" label="Display" value={"1920x1080"} />
+                              <Row branch="mid" label="Disk" value={"120 / 500 GiB (24%)"} />
+                              <Row branch="mid" label="Memory" value={"8 / 16 GiB (50%)"} />
+                              <Row branch="last" label="Swap" value={"0 / 4 GiB (0%)"} />
+                              <div style={{ color: dim }}>{bot}</div>
+                            </div>
 
-                      <div>
-                        <div style={{ color: colors.color8 ?? "#666" }}>{`┌──────── Software ────────`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color1 ?? "#ff5555" }}>OS</span>{`: Omarchy`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color2 ?? "#50fa7b" }}>Kernel</span>{`: linux-arch`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color3 ?? "#f1fa8c" }}>WM</span>{`: Hyprland (Wayland)`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color4 ?? "#6272a4" }}>Shell</span>{`: bash`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color5 ?? "#ff79c6" }}>Terminal</span>{`: ghostty`}</div>
-                        <div>
-                          {`│ `}<span style={{ color: colors.accent ?? colors.color6 ?? "#8be9fd" }}>Theme</span>{`: ${theme.name} `}
-                          {["color1","color2","color3","color4","color5","color6","color7","color8"].map((k) => (
-                            <span key={k} style={{ color: colors[k] ?? "#888" }}>●</span>
-                          ))}
-                        </div>
-                        <div>{`│ `}<span style={{ color: colors.color6 ?? "#8be9fd" }}>Font</span>{`: JetBrainsMono Nerd Font`}</div>
-                        <div style={{ color: colors.color8 ?? "#666" }}>{`└──────────────────────────`}</div>
-                      </div>
+                            <div>
+                              <div style={{ color: dim }}>{top("Software")}</div>
+                              <Row branch="first" label="OS" value={"Omarchy"} />
+                              <Row branch="mid" label="Branch" value={"master"} />
+                              <Row branch="mid" label="Kernel" value={"linux-arch"} />
+                              <Row branch="mid" label="WM" value={"Hyprland (Wayland)"} />
+                              <Row branch="mid" label="Terminal" value={termStyle?.source?.replace(".conf","").replace(".toml","") ?? "ghostty"} />
+                              <Row branch="mid" label="Packages" value={"1024 (pacman)"} />
+                              <Row
+                                branch="mid"
+                                label="Theme"
+                                value={
+                                  <>
+                                    {theme.name + " "}
+                                    {["color1","color2","color3","color4","color5","color6","color7","color8"].map((k) => (
+                                      <span key={k} style={{ color: colors[k] ?? "#888" }}>●</span>
+                                    ))}
+                                  </>
+                                }
+                              />
+                              <Row branch="last" label="Font" value={termFont ? `${termFont} (9pt)` : "JetBrainsMono Nerd Font (9pt)"} />
+                              <div style={{ color: dim }}>{bot}</div>
+                            </div>
 
-                      <div>
-                        <div style={{ color: colors.color8 ?? "#666" }}>{`┌──────── Session ─────────`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color3 ?? "#f1fa8c" }}>Uptime</span>{`: 2 hours`}</div>
-                        <div>{`│ `}<span style={{ color: colors.color2 ?? "#50fa7b" }}>Packages</span>{`: 1024 (pacman)`}</div>
-                        <div style={{ color: colors.color8 ?? "#666" }}>{`└──────────────────────────`}</div>
-                      </div>
+                            <div>
+                              <div style={{ color: dim }}>{top("Uptime / Age")}</div>
+                              <Row branch="first" label="OS Age" value={"0 days"} />
+                              <Row branch="last" label="Uptime" value={"2 hours, 13 mins"} />
+                              <div style={{ color: dim }}>{bot}</div>
+                            </div>
+                          </>
+                        );
+                      })()}
                     </div>
+                  </div>
+
+                  <div className="pt-4">
+                    <span style={{ color: colors.color2 ?? colors.accent ?? "#50fa7b" }}>user@omarchy</span>
+                    <span>:</span>
+                    <span style={{ color: colors.color4 ?? "#6272a4" }}>~</span>
+                    <span> $ </span>
+                    <span
+                      className="inline-block align-middle animate-pulse"
+                      style={{
+                        backgroundColor: colors.cursor ?? colors.accent ?? "#4a9eff",
+                        width: cursorStyle === "beam" ? "1px" : "8px",
+                        height: cursorStyle === "underline" ? "2px" : "16px",
+                        verticalAlign: cursorStyle === "underline" ? "bottom" : "middle",
+                      }}
+                    />
                   </div>
                 </div>
               </Card>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -30,6 +30,7 @@ export interface Theme {
   github_pushed_at: string | null;
   overlays_builtin: string | null;
   security_warnings: string | null;
+  terminal_style_json: string | null;
 }
 
 const allThemes = themesData as Theme[];

--- a/worker/migrations/0001_terminal_style.sql
+++ b/worker/migrations/0001_terminal_style.sql
@@ -1,0 +1,1 @@
+ALTER TABLE themes ADD COLUMN terminal_style_json TEXT;

--- a/worker/schema.sql
+++ b/worker/schema.sql
@@ -19,6 +19,7 @@ CREATE TABLE IF NOT EXISTS themes (
   canonical_github_url TEXT,
   overlays_builtin TEXT,
   security_warnings TEXT,
+  terminal_style_json TEXT,
   last_scraped_at TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))

--- a/worker/scraper.ts
+++ b/worker/scraper.ts
@@ -65,6 +65,7 @@ interface ThemeRecord {
   canonical_github_url: string | null;
   overlays_builtin: string | null;
   security_warnings: string | null;
+  terminal_style_json: string | null;
 }
 
 interface ScrapeResult {
@@ -356,6 +357,193 @@ function parseAlacrittyColors(tomlContent: string): Record<string, string> | nul
   } catch {
     return null;
   }
+}
+
+// ---------------------------------------------------------------------------
+// Parse terminal window style (ghostty.conf > kitty.conf > alacritty.toml)
+// + corner rounding from hyprland.conf
+// ---------------------------------------------------------------------------
+
+interface TerminalStyle {
+  source: "ghostty.conf" | "kitty.conf" | "alacritty.toml";
+  background_opacity?: number;
+  padding?: number;
+  font_family?: string;
+  cursor_style?: "block" | "beam" | "underline";
+  rounding?: number;
+}
+
+function stripQuotes(v: string): string {
+  return v.replace(/^["']|["']$/g, "");
+}
+
+function parseFlatConfig(content: string, mode: "equals" | "space"): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const raw of content.split("\n")) {
+    const line = raw.replace(/#.*$/, "").trim();
+    if (!line) continue;
+    let key: string | undefined;
+    let value: string | undefined;
+    if (mode === "equals") {
+      const eq = line.indexOf("=");
+      if (eq !== -1) {
+        key = line.slice(0, eq).trim();
+        value = line.slice(eq + 1).trim();
+      } else {
+        const m = line.match(/^(\S+)\s+(.+)$/);
+        if (m) { key = m[1]; value = m[2]; }
+      }
+    } else {
+      const m = line.match(/^(\S+)\s+(.+)$/);
+      if (m) { key = m[1]; value = m[2]; }
+    }
+    if (key && value !== undefined) out.set(key, stripQuotes(value.trim()));
+  }
+  return out;
+}
+
+function clamp01(n: number): number {
+  if (Number.isNaN(n)) return 1;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function normalizeCursorStyle(v: string): "block" | "beam" | "underline" | undefined {
+  const s = v.toLowerCase();
+  if (s.includes("beam") || s.includes("bar") || s.includes("ibeam")) return "beam";
+  if (s.includes("underline") || s.includes("under")) return "underline";
+  if (s.includes("block")) return "block";
+  return undefined;
+}
+
+function parseGhosttyStyle(content: string): Omit<TerminalStyle, "source" | "rounding"> {
+  const cfg = parseFlatConfig(content, "equals");
+  const out: Omit<TerminalStyle, "source" | "rounding"> = {};
+  const op = cfg.get("background-opacity");
+  if (op !== undefined) out.background_opacity = clamp01(parseFloat(op));
+  const px = cfg.get("window-padding-x");
+  const py = cfg.get("window-padding-y");
+  if (px !== undefined || py !== undefined) {
+    const a = parseFloat(px ?? py ?? "0");
+    const b = parseFloat(py ?? px ?? "0");
+    if (!Number.isNaN(a) && !Number.isNaN(b)) out.padding = Math.max(a, b);
+  }
+  const ff = cfg.get("font-family");
+  if (ff) out.font_family = ff;
+  const cs = cfg.get("cursor-style");
+  if (cs) out.cursor_style = normalizeCursorStyle(cs);
+  return out;
+}
+
+function parseKittyStyle(content: string): Omit<TerminalStyle, "source" | "rounding"> {
+  const cfg = parseFlatConfig(content, "space");
+  const out: Omit<TerminalStyle, "source" | "rounding"> = {};
+  const op = cfg.get("background_opacity");
+  if (op !== undefined) out.background_opacity = clamp01(parseFloat(op));
+  const pad = cfg.get("window_padding_width");
+  if (pad !== undefined) {
+    const n = parseFloat(pad.split(/\s+/)[0]);
+    if (!Number.isNaN(n)) out.padding = n;
+  }
+  const ff = cfg.get("font_family");
+  if (ff) out.font_family = ff;
+  const cs = cfg.get("cursor_shape");
+  if (cs) out.cursor_style = normalizeCursorStyle(cs);
+  return out;
+}
+
+function parseAlacrittyStyle(tomlContent: string): Omit<TerminalStyle, "source" | "rounding"> | null {
+  try {
+    const parsed = parseTOML(tomlContent) as Record<string, unknown>;
+    const out: Omit<TerminalStyle, "source" | "rounding"> = {};
+    const win = parsed.window as Record<string, unknown> | undefined;
+    if (win) {
+      if (typeof win.opacity === "number") out.background_opacity = clamp01(win.opacity);
+      const pad = win.padding as Record<string, number> | undefined;
+      if (pad && (typeof pad.x === "number" || typeof pad.y === "number")) {
+        out.padding = Math.max(pad.x ?? 0, pad.y ?? 0);
+      }
+    }
+    const font = parsed.font as Record<string, unknown> | undefined;
+    if (font) {
+      const normal = font.normal as Record<string, unknown> | undefined;
+      if (normal && typeof normal.family === "string") out.font_family = normal.family;
+    }
+    const cursor = parsed.cursor as Record<string, unknown> | undefined;
+    if (cursor) {
+      const style = cursor.style;
+      if (typeof style === "string") out.cursor_style = normalizeCursorStyle(style);
+      else if (style && typeof style === "object") {
+        const shape = (style as Record<string, unknown>).shape;
+        if (typeof shape === "string") out.cursor_style = normalizeCursorStyle(shape);
+      }
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function parseHyprlandRounding(content: string): number | undefined {
+  // decoration { rounding = N }  or top-level `rounding = N` inside a decoration block
+  const m = content.match(/decoration\s*\{[^}]*?\brounding\s*=\s*(\d+(?:\.\d+)?)/s);
+  if (m) {
+    const n = parseFloat(m[1]);
+    if (!Number.isNaN(n)) return n;
+  }
+  return undefined;
+}
+
+async function fetchTerminalStyle(
+  owner: string,
+  repo: string,
+  pathPrefix: string,
+  token?: string,
+): Promise<TerminalStyle | null> {
+  let style: Omit<TerminalStyle, "source" | "rounding"> | null = null;
+  let source: TerminalStyle["source"] | undefined;
+
+  const ghostty = await fetchFileContent(owner, repo, `${pathPrefix}ghostty.conf`, token);
+  if (ghostty) {
+    style = parseGhosttyStyle(ghostty);
+    source = "ghostty.conf";
+  } else {
+    const kitty = await fetchFileContent(owner, repo, `${pathPrefix}kitty.conf`, token);
+    if (kitty) {
+      style = parseKittyStyle(kitty);
+      source = "kitty.conf";
+    } else {
+      const alacritty = await fetchFileContent(owner, repo, `${pathPrefix}alacritty.toml`, token);
+      if (alacritty) {
+        style = parseAlacrittyStyle(alacritty);
+        if (style) source = "alacritty.toml";
+      }
+    }
+  }
+
+  // Pull rounding from hyprland.conf regardless of which terminal config was found.
+  let rounding: number | undefined;
+  const hypr = await fetchFileContent(owner, repo, `${pathPrefix}hyprland.conf`, token);
+  if (hypr) rounding = parseHyprlandRounding(hypr);
+
+  if (!style && rounding === undefined) return null;
+  if (!source && rounding !== undefined) source = "alacritty.toml"; // placeholder; only rounding present
+
+  const result: TerminalStyle = { source: source! };
+  if (style) Object.assign(result, style);
+  if (rounding !== undefined) result.rounding = rounding;
+
+  // Drop empty payloads
+  const hasAny =
+    result.background_opacity !== undefined ||
+    result.padding !== undefined ||
+    result.font_family !== undefined ||
+    result.cursor_style !== undefined ||
+    result.rounding !== undefined;
+  if (!hasAny) return null;
+
+  return result;
 }
 
 // ---------------------------------------------------------------------------
@@ -674,6 +862,8 @@ async function scrapeTheme(
     primaryHue = computeHueBucket(colors.accent);
   }
 
+  const terminalStyle = await fetchTerminalStyle(owner, repo, pathPrefix, token);
+
   const branch = meta.default_branch;
 
   // Fetch tree once — used for app detection and image finding
@@ -721,6 +911,7 @@ async function scrapeTheme(
     canonical_github_url: canonicalGithubUrl,
     overlays_builtin: overlaysBuiltin,
     security_warnings: allWarnings.length > 0 ? JSON.stringify(allWarnings) : null,
+    terminal_style_json: terminalStyle ? JSON.stringify(terminalStyle) : null,
   };
 
   if (allWarnings.length > 0) {
@@ -741,8 +932,8 @@ async function upsertTheme(db: D1Database, theme: ThemeRecord): Promise<void> {
         id, name, slug, github_url, github_owner, github_repo,
         description, preview_url, colors_json, apps_json, primary_hue,
         is_builtin, is_curated, stars, readme_text, default_branch,
-        github_pushed_at, canonical_github_url, overlays_builtin, security_warnings, last_scraped_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+        github_pushed_at, canonical_github_url, overlays_builtin, security_warnings, terminal_style_json, last_scraped_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))
       ON CONFLICT(id) DO UPDATE SET
         name = excluded.name,
         github_url = excluded.github_url,
@@ -762,6 +953,7 @@ async function upsertTheme(db: D1Database, theme: ThemeRecord): Promise<void> {
         canonical_github_url = excluded.canonical_github_url,
         overlays_builtin = excluded.overlays_builtin,
         security_warnings = excluded.security_warnings,
+        terminal_style_json = excluded.terminal_style_json,
         last_scraped_at = datetime('now'),
         updated_at = datetime('now')`,
     )
@@ -786,6 +978,7 @@ async function upsertTheme(db: D1Database, theme: ThemeRecord): Promise<void> {
       theme.canonical_github_url,
       theme.overlays_builtin,
       theme.security_warnings,
+      theme.terminal_style_json,
     )
     .run();
 }
@@ -1059,7 +1252,7 @@ async function dumpThemes(db: D1Database, validSlugs: Set<string>): Promise<unkn
               description, preview_url, colors_json, apps_json, primary_hue,
               is_builtin, is_curated, stars, readme_text, default_branch,
               last_scraped_at, created_at, updated_at, github_pushed_at,
-              overlays_builtin, security_warnings
+              overlays_builtin, security_warnings, terminal_style_json
        FROM themes ORDER BY stars DESC`
     )
     .all();


### PR DESCRIPTION
## Summary
- Worker scrapes terminal window style (background opacity, padding, font family, cursor shape) from `ghostty.conf` > `kitty.conf` > `alacritty.toml` in that priority order
- Worker also pulls corner rounding from each theme's `hyprland.conf` (`decoration { rounding = N }`)
- Stored as `terminal_style_json` (new D1 column, nullable)
- Theme detail preview card applies the scraped values: rgba background with `backdrop-filter: blur` for low-opacity themes, `border-radius` from hyprland rounding, padding + font-family from terminal config, cursor shape variants
- Fastfetch block inside the preview now matches real Omarchy fastfetch layout — tree branches (`│ ├` / `│ └`), full box enclosure on Hardware / Software / Uptime sections, all labels in `keyColor` (color2/accent), palette dots inline on the Theme row

## Operational
- D1 migration `0001_terminal_style.sql` already applied to remote db
- Worker already deployed and full re-scrape complete (141/277 themes had usable terminal config to extract from)
- Local `themes-data.json` regenerated against the refreshed scraper

## Test plan
- [ ] `/themes/lasthorizon` renders with near-square corners (`rounding: 3` from hyprland.conf)
- [ ] A theme with low background opacity renders with translucent terminal card
- [ ] A theme without any terminal config renders the preview with sensible defaults (no crashes)
- [ ] Preview no longer shows horizontal scrollbar at default desktop widths