### PR TITLE
Apple-style concentric corner radius cascade

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,13 +49,13 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
-  --radius-sm: calc(var(--radius) * 0.6);
-  --radius-md: calc(var(--radius) * 0.8);
+  --radius-sm: calc(var(--radius) - 8px);
+  --radius-md: calc(var(--radius) - 4px);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) * 1.4);
-  --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --radius-3xl: calc(var(--radius) + 12px);
+  --radius-4xl: calc(var(--radius) + 16px);
 }
 
 :root {
@@ -82,7 +82,7 @@
   --chart-3: oklch(0.546 0.245 262.881);
   --chart-4: oklch(0.488 0.243 264.376);
   --chart-5: oklch(0.424 0.199 265.638);
-  --radius: 0.625rem;
+  --radius: 12px;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
   --sidebar-primary: oklch(0.205 0 0);


### PR DESCRIPTION
## Summary
- Bumped base \`--radius\` from \`0.625rem\` (10px) to \`12px\` — Apple's typical medium-card radius
- Replaced the multiplier-based cascade (× 0.6 / 0.8 / 1.0 / 1.4 / 1.8 …) with a fixed 4px-step cascade so every level differs by exactly one inset distance from its neighbour
- Result: \`sm 4 → md 8 → lg 12 → xl 16 → 2xl 20 → 3xl 24 → 4xl 28\` — matches Apple's concentric corner formula where \`inner = outer − inset\`

## Test plan
- [ ] Browse page cards / sidebar / inputs look uniformly rounded, not mismatched
- [ ] Theme detail page outer Card vs inner buttons / palette swatches look concentric
- [ ] No visual regressions on mobile breakpoints