### PR TITLE
Use frozen lockfile in nightly scrape workflow

### DIFF
--- a/.github/workflows/refresh-themes.yml
+++ b/.github/workflows/refresh-themes.yml
@@ -19,7 +19,11 @@ jobs:
         with:
           node-version: 24
 
-      - run: npm install
+      - uses: oven-sh/setup-bun@v2
+
+      # Frozen lockfile: install exactly what bun.lock pins, never resolve
+      # fresh semver ranges in CI (supply-chain hardening).
+      - run: bun install --frozen-lockfile
 
       - name: Scrape themes from GitHub
         run: node scripts/scrape.js


### PR DESCRIPTION
## Summary
- Replaces `npm install` (no lockfile — resolved fresh semver ranges nightly) with `bun install --frozen-lockfile` against the committed `bun.lock`
- Closes the supply-chain gap where a malicious patch release of any dep/transitive dep would execute in CI with `contents: write` to main
- Node stays the runtime for the scraper; bun is only the installer

## Test plan
- [x] `bun install --frozen-lockfile` from clean worktree installs all 80 packages
- [x] `LIMIT=1 node scripts/scrape.js` smoke test passes against the frozen install