### PR TITLE
Filter clicks push history entries; typing replaces

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -38,7 +38,7 @@
       const input = document.querySelector('[name="author"]');
       if (input) {
         input.value = author;
-        input.dispatchEvent(new Event("input", { bubbles: true }));
+        document.dispatchEvent(new CustomEvent("author-filter", { detail: author }));
       }
     } else {
       window.location.href = `/themes/?author=${encodeURIComponent(author)}`;
@@ -93,7 +93,17 @@
     if (state.view) p.set("view", state.view);
     const qs = p.toString();
     const url = qs ? `${location.pathname}?${qs}` : location.pathname;
-    history.replaceState(null, "", url);
+    return url;
+  }
+
+  // Clicks are navigation-like: they push a history entry so Back unwinds
+  // the filter change. Typing replaces in place (no entry per keystroke).
+  function update(push = false) {
+    const url = writeURL();
+    if (url !== location.pathname + location.search) {
+      history[push ? "pushState" : "replaceState"](null, "", url);
+    }
+    syncInputs(); applyFilters();
   }
 
   function syncInputs() {
@@ -152,28 +162,27 @@
     if (empty) empty.hidden = visible !== 0;
   }
 
-  function update() { writeURL(); syncInputs(); applyFilters(); }
-
   inputs.q?.addEventListener("input", () => { state.q = inputs.q.value; update(); });
   inputs.author?.addEventListener("input", () => { state.author = inputs.author.value; update(); });
+  document.addEventListener("author-filter", (e) => { state.author = e.detail; update(true); });
 
-  inputs.sort.forEach((b) => b.addEventListener("click", () => { state.sort = b.value; update(); }));
-  inputs.source.forEach((b) => b.addEventListener("click", () => { state.source = b.value; update(); }));
-  inputs.brightness.forEach((b) => b.addEventListener("click", () => { state.brightness = b.value; update(); }));
-  inputs.view.forEach((b) => b.addEventListener("click", () => { state.view = b.value; update(); }));
+  inputs.sort.forEach((b) => b.addEventListener("click", () => { state.sort = b.value; update(true); }));
+  inputs.source.forEach((b) => b.addEventListener("click", () => { state.source = b.value; update(true); }));
+  inputs.brightness.forEach((b) => b.addEventListener("click", () => { state.brightness = b.value; update(true); }));
+  inputs.view.forEach((b) => b.addEventListener("click", () => { state.view = b.value; update(true); }));
   inputs.color.forEach((b) => b.addEventListener("click", () => {
     const idx = state.color.indexOf(b.value);
     if (idx === -1) state.color.push(b.value); else state.color.splice(idx, 1);
-    update();
+    update(true);
   }));
-  document.querySelector("[data-color-all]")?.addEventListener("click", () => { state.color = []; update(); });
+  document.querySelector("[data-color-all]")?.addEventListener("click", () => { state.color = []; update(true); });
 
   document.querySelectorAll("[data-clear]").forEach((btn) => {
     btn.addEventListener("click", () => {
       const target = btn.getAttribute("data-clear");
       if (target === "q") { state.q = ""; }
       if (target === "author") { state.author = ""; }
-      update();
+      update(true);
     });
   });
 

--- a/public/app.js
+++ b/public/app.js
@@ -41,7 +41,7 @@
         document.dispatchEvent(new CustomEvent("author-filter", { detail: author }));
       }
     } else {
-      window.location.href = `/themes/?author=${encodeURIComponent(author)}`;
+      window.location.href = `/themes/?author=${encodeURIComponent(author)}&source=all`;
     }
   });
 
@@ -164,7 +164,13 @@
 
   inputs.q?.addEventListener("input", () => { state.q = inputs.q.value; update(); });
   inputs.author?.addEventListener("input", () => { state.author = inputs.author.value; update(); });
-  document.addEventListener("author-filter", (e) => { state.author = e.detail; update(true); });
+  document.addEventListener("author-filter", (e) => {
+    state.author = e.detail;
+    // An author click means "show me everything by this person" — don't let
+    // the default community-only source filter veto builtin authors.
+    state.source = "all";
+    update(true);
+  });
 
   inputs.sort.forEach((b) => b.addEventListener("click", () => { state.sort = b.value; update(true); }));
   inputs.source.forEach((b) => b.addEventListener("click", () => { state.source = b.value; update(true); }));


### PR DESCRIPTION
## Problem
All browse-filter changes used `history.replaceState`, so a click (author name on a card, a brightness/source/view/sort pill, a color dot) replaced the `/themes/` history entry. Pressing Back after clicking an author skipped to whatever page preceded browse instead of returning to the unfiltered grid.

## Fix
`update(push)` distinguishes interaction types:
- **Clicks push** — author links, pills, color dots, color-all, clear buttons → Back unwinds the filter change
- **Typing replaces** — `q`/`author` input events keep `replaceState` so each keystroke doesn't create a history entry
- No-op URL writes skip history entirely; the existing `popstate` handler restores state on Back/Forward

Author-link clicks route through a `CustomEvent` instead of a synthetic `input` event so they take the push path.

## Verification
Local build + browser: clicked an author → `?author=…` filtered grid; Back → unfiltered `/themes/` with the input cleared. Pill click → `?brightness=dark`; Back → cleared. `node --check public/app.js` clean.

(Found while porting this site's filter UX to its sibling, huduthemes.com — same fix is live there.)