### PR TITLE
Add HSTS and CSP base-uri/form-action directives

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,4 +3,5 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com 'sha256-IzqPEEZMpEPyaI7ZbB/Ri4vh8EmC0mfj39mjPCJ2cWU='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://cloudflareinsights.com; frame-ancestors 'none'
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://static.cloudflareinsights.com 'sha256-IzqPEEZMpEPyaI7ZbB/Ri4vh8EmC0mfj39mjPCJ2cWU='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https: data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://cloudflareinsights.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none'


### PR DESCRIPTION
Static-site hardening for the response headers served by Cloudflare Pages.

- **Add `Strict-Transport-Security: max-age=31536000; includeSubDomains`** — was absent; pins HTTPS for return visits. No `preload` (avoids the irreversible preload-list commitment).
- **Add `base-uri 'self'` and `form-action 'self'` to the CSP** — `default-src` does not cover either directive, so a `<base>` hijack could rewrite relative URLs past the policy. Verified safe: no `<base>` tag and no `<form>` in the codebase.

Build verified locally; `_headers` propagates to `out/` unchanged in shape.