### PR TITLE
Add structured discussion category forms

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,50 @@
+labels: ["theme-help"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Stuck on installing, applying, or customizing a theme? Share the details below so people can help.
+  - type: input
+    id: theme
+    attributes:
+      label: Which theme?
+      description: The theme name (or its GitHub URL).
+      placeholder: e.g. tokyo-night
+    validations:
+      required: false
+  - type: dropdown
+    id: terminal
+    attributes:
+      label: Terminal
+      options:
+        - Ghostty
+        - Kitty
+        - Alacritty
+        - Foot
+        - Other / not sure
+      default: 0
+    validations:
+      required: false
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's happening?
+      description: What did you try, what did you expect, and what actually happened?
+      placeholder: Ran omarchy-theme-install <url>, but the colors didn't change...
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Omarchy / OS version
+      description: Helps narrow things down.
+      placeholder: e.g. Omarchy on Arch, updated this week
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before posting
+      options:
+        - label: I checked the existing Q&A discussions for the same problem
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,30 @@
+labels: ["rice"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Show off your desktop! Drop a screenshot, tell us what you're running, and link your dotfiles if you've got them.
+  - type: input
+    id: theme
+    attributes:
+      label: Theme used
+      description: Which theme (or themes) is your setup running?
+      placeholder: e.g. catppuccin-mocha
+    validations:
+      required: true
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot
+      description: Drag and drop an image here.
+      placeholder: Paste or drop your screenshot...
+    validations:
+      required: true
+  - type: input
+    id: dotfiles
+    attributes:
+      label: Dotfiles link
+      description: Optional — share your config so others can recreate it.
+      placeholder: https://github.com/...
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/theme-requests.yml
+++ b/.github/DISCUSSION_TEMPLATE/theme-requests.yml
@@ -1,0 +1,53 @@
+title: "[Request] "
+labels: ["theme-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Want a theme that doesn't exist yet? Describe it here and someone in the community might build it.
+
+        Looking to share a theme you've already made? Use [Submit a Theme](https://github.com/limehawk/omarchy-theme-website/issues/new?template=submit-theme.yml) instead.
+  - type: input
+    id: name
+    attributes:
+      label: Theme name or inspiration
+      description: What would you call it, or what's it based on?
+      placeholder: e.g. "Solarized but warmer", a movie, a brand, another app's palette
+    validations:
+      required: true
+  - type: textarea
+    id: look
+    attributes:
+      label: What should it look like?
+      description: Describe the mood, key colors, and anything specific you have in mind.
+      placeholder: Muted earth tones, low contrast, a soft amber accent...
+    validations:
+      required: true
+  - type: input
+    id: references
+    attributes:
+      label: Reference links
+      description: Palettes, screenshots, or apps to match (optional but helps a lot).
+      placeholder: https://...
+    validations:
+      required: false
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Light or dark?
+      options:
+        - Dark
+        - Light
+        - Both
+      default: 0
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before posting
+      options:
+        - label: I searched existing themes in the gallery and didn't find this
+          required: true
+        - label: I searched open requests and this isn't already requested
+          required: true


### PR DESCRIPTION
Adds discussion category forms (`.github/DISCUSSION_TEMPLATE/`) so Discussions collect structured input instead of free-form posts — same mechanism as the existing Submit a Theme issue form.

## Forms
- **theme-requests.yml** — request a theme that doesn't exist yet (inspiration, desired look, references, light/dark). Distinct from submitting a theme you've already built.
- **q-a.yml** — install/customization help on the existing Q&A category (theme, terminal, problem, OS).
- **show-and-tell.yml** — desktop showcases on the existing Show and tell category (theme used, screenshot, dotfiles).

Labels referenced by the forms (`theme-request`, `theme-help`, `rice`) already exist in the repo.

## Manual step required before the Theme Requests form activates
GitHub has no API for creating discussion categories, so the category must be made in the web UI:

1. Repo → **Discussions** → **Edit categories** (pencil) → **New category**
2. Name: **Theme Requests**, format: **Open discussion**, pick an emoji (🎨)
3. Confirm its slug is `theme-requests` (auto-derived from the name — must match the form filename)

`q-a` and `show-and-tell` already exist, so those two forms take effect as soon as this merges to `main`. Discussion forms only apply from the default branch.