### PR TITLE
feat(scrape): tag theme author in dead-repo issues

### DIFF
--- a/scripts/scrape.js
+++ b/scripts/scrape.js
@@ -689,10 +689,22 @@ async function fileDeadRepoIssues(deadRepos) {
       continue;
     }
 
+    // Tag the author so they can weigh in — but only if the account still
+    // exists. A repo most often 404s because the account was deleted (renames
+    // 301-redirect and don't reach here), and @mentioning a deleted handle
+    // renders as dead text that notifies no one.
+    const { owner } = parseOwnerRepo(dead.url);
+    const userRes = await githubFetch(`https://api.github.com/users/${owner}`);
+    const authorLine = userRes.ok
+      ? `- **Author:** @${owner} — can you confirm whether this repo moved or was taken down?`
+      : `- **Author:** \`${owner}\` (GitHub account no longer exists)`;
+
     const body = `The theme **${dead.entry}** returned HTTP 404 during the nightly scrape.
 
 ` +
       `- **URL:** ${dead.url}
+` +
+      `${authorLine}
 ` +
       `- **Action needed:** Check if the repo was renamed/moved. Update \`themes.json\` with the new URL or mark as \`"dead": true\` if permanently gone.
 `;


### PR DESCRIPTION
## What

When the nightly scraper files a `dead-theme` issue for a repo that 404s, it now @-mentions the repo owner so they can weigh in on whether the repo moved or was taken down.

## Guard: only tag live accounts

A repo 404s for three reasons, and only some make a tag useful:

| Why it 404s | `@owner` notifies them? |
|---|---|
| Renamed / moved | ✅ (but these 301-redirect and usually never reach the issue-filer) |
| Made private | ✅ account's alive |
| **Account deleted** | ❌ dead gray text, pings no one |

So before tagging, we hit `api.github.com/users/{owner}`. Live → `@owner` with a prompt to confirm. Gone → a plain `account no longer exists` note. One extra API call per dead repo; dead repos are rare.

Motivating case: issue #75 (Colored Darkness / `Palccod`) — that account was deleted, so a bare `@Palccod` would have notified nobody. Confirmed via clean 404 with no redirect vs. a control renamed repo returning 301.

## Test
- `node --check scripts/scrape.js` passes.