### PR TITLE
chore: mark Colored Darkness theme as dead

### DIFF
--- a/src/data/themes.json
+++ b/src/data/themes.json
@@ -247,6 +247,7 @@
     },
     {
       "name": "Colored Darkness",
+      "dead": true,
       "url": "https://github.com/Palccod/colored-darkness"
     },
     {


### PR DESCRIPTION
Flags `Colored Darkness` as `dead: true` in `themes.json`. The repo `Palccod/colored-darkness` 404s because the GitHub account was deleted (clean 404, no rename redirect). URL kept as a historical record per convention.

Closes #75.