### PR TITLE
feat(scrape): include omarchytheme.com live page link in dead-repo issues

### DIFF
--- a/scripts/scrape.js
+++ b/scripts/scrape.js
@@ -659,6 +659,7 @@ async function generateThumbnails(rawRecords) {
 // ---------- dead-repo issue filing ----------
 
 const SITE_REPO = process.env.GITHUB_REPOSITORY || "limehawk/omarchy-theme-website";
+const SITE_URL = "https://omarchytheme.com";
 
 async function fileDeadRepoIssues(deadRepos) {
   if (!GITHUB_TOKEN) {
@@ -703,6 +704,8 @@ async function fileDeadRepoIssues(deadRepos) {
 
 ` +
       `- **URL:** ${dead.url}
+` +
+      `- **Live page:** ${SITE_URL}/themes/${dead.slug}/ (still serving cached data — remove once marked dead)
 ` +
       `${authorLine}
 ` +
@@ -793,7 +796,7 @@ async function main() {
         rawRecords.push({ ...cached, _from_cache: true });
         reusedFromCache.push(entry.name);
       }
-      errors.push({ entry: entry.name, url: entry.url, error: results[i].error.message, httpStatus: results[i].error.httpStatus });
+      errors.push({ entry: entry.name, url: entry.url, slug, error: results[i].error.message, httpStatus: results[i].error.httpStatus });
     }
   }
 


### PR DESCRIPTION
## What

Dead-repo issues now include a link to the theme's own live page on `omarchytheme.com`, alongside the GitHub URL and author tag from #80.

## Why

A theme that starts 404ing isn't pulled from the site immediately — the scraper reuses its last-known cached record until someone marks it `"dead": true` in `themes.json`. So at the time the issue is filed, the page is still live and viewable. Linking it gives reviewers (and the tagged author) something to click through to, instead of just a dead GitHub URL.

## Test
- `node --check scripts/scrape.js` passes