### PR TITLE
Shuffle popular themes among all themes over 50 stars

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -48,25 +48,36 @@ function copyRecursive(src, dest) {
 
 // ---------- data selection (ported from src/lib/db.ts) ----------
 
-function getFeaturedThemes(themes, limit = 6) {
-  return themes
-    .filter((t) => t.is_builtin === 0)
-    .sort((a, b) => b.stars - a.stars)
-    .slice(0, limit);
-}
-
-function getRandomThemes(themes, count, exclude) {
-  const candidates = themes.filter((t) => t.is_builtin === 0 && !exclude.has(t.id));
+// Deterministic daily shuffle: same order for a given UTC day, reshuffles each day.
+function dailyShuffle(items) {
   const seed = new Date().toISOString().slice(0, 10);
   let hash = 0;
   for (let i = 0; i < seed.length; i++) hash = ((hash << 5) - hash + seed.charCodeAt(i)) | 0;
-  const shuffled = [...candidates];
+  const shuffled = [...items];
   for (let i = shuffled.length - 1; i > 0; i--) {
     hash = ((hash << 5) - hash + i) | 0;
     const j = (hash >>> 0) % (i + 1);
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
-  return shuffled.slice(0, count);
+  return shuffled;
+}
+
+const POPULAR_STAR_THRESHOLD = 50;
+
+function getFeaturedThemes(themes, limit = 6) {
+  const community = themes.filter((t) => t.is_builtin === 0);
+  const pool = community.filter((t) => t.stars > POPULAR_STAR_THRESHOLD);
+  // Shuffle among all "popular" themes so the section rotates daily. If too few
+  // clear the threshold to fill the section, fall back to top themes by stars.
+  const selection = pool.length >= limit
+    ? dailyShuffle(pool)
+    : [...community].sort((a, b) => b.stars - a.stars);
+  return selection.slice(0, limit);
+}
+
+function getRandomThemes(themes, count, exclude) {
+  const candidates = themes.filter((t) => t.is_builtin === 0 && !exclude.has(t.id));
+  return dailyShuffle(candidates).slice(0, count);
 }
 
 function getFeaturedAuthor(themes, exclude) {

--- a/scripts/render.js
+++ b/scripts/render.js
@@ -472,14 +472,16 @@ export function renderReadme(content, owner, repo, branch, pathPrefix = "") {
     ...SANITIZE_OPTS,
     transformTags: {
       ...SANITIZE_OPTS.transformTags,
-      img: (tag, attrs) => ({
-        tagName: "img",
-        attribs: {
-          ...attrs,
-          src: resolveReadmeUrl(attrs.src, owner, repo, branch, pathPrefix),
-          loading: "lazy",
-        },
-      }),
+      img: (tag, attrs) => {
+        const src = resolveReadmeUrl(attrs.src, owner, repo, branch, pathPrefix);
+        // A src-less <img> (malformed README markup) resolves to undefined and
+        // crashes sanitize-html's URL check — drop it rather than emit a broken tag.
+        if (!src) return { tagName: "img", attribs: {} };
+        return {
+          tagName: "img",
+          attribs: { ...attrs, src, loading: "lazy" },
+        };
+      },
     },
   });
 


### PR DESCRIPTION
## What
The homepage **popular themes** section now shuffles among *all* community themes with more than 50 stars, instead of always showing the same fixed top-6. It uses the same deterministic daily-seed shuffle as the `discover` section, so the lineup rotates each day and every theme over the threshold gets rotation into the spotlight. Falls back to top-by-stars if fewer than 6 themes clear the threshold.

11 community themes currently qualify (>50 stars), so 6 are shown per day.

## Also fixed (build blocker)
While verifying, `npm run build` was failing outright — a src-less `<img>` in the Copper Night README resolved to an undefined URL and crashed `sanitize-html`. The README renderer now drops such images instead of emitting a broken tag. This was pre-existing on `main` and blocked *any* deploy.

## Verification
- `npm run build` completes cleanly (was crashing before the img fix)
- Homepage popular section renders a shuffled >50-star subset (verified in generated `out/index.html`)
- Selection is deterministic per UTC day, matching the discover section